### PR TITLE
Fix junit log error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 ######################
 /build/resources/main/static/**
 /src/test/javascript/coverage/
+/src/main/resources/config/application-local.yml
 
 ######################
 # Node

--- a/src/test/java/com/icthh/xm/ms/mstemplate/IntegrationTest.java
+++ b/src/test/java/com/icthh/xm/ms/mstemplate/IntegrationTest.java
@@ -1,0 +1,19 @@
+package com.icthh.xm.ms.mstemplate;
+
+import com.icthh.xm.commons.web.spring.config.JacksonConfiguration;
+import com.icthh.xm.ms.mstemplate.config.AsyncSyncConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Base composite annotation for integration tests.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(classes = { MstemplateApp.class, JacksonConfiguration.class, AsyncSyncConfiguration.class })
+public @interface IntegrationTest {
+}

--- a/src/test/java/com/icthh/xm/ms/mstemplate/config/AsyncSyncConfiguration.java
+++ b/src/test/java/com/icthh/xm/ms/mstemplate/config/AsyncSyncConfiguration.java
@@ -1,0 +1,16 @@
+package com.icthh.xm.ms.mstemplate.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SyncTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncSyncConfiguration {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        return new SyncTaskExecutor();
+    }
+}

--- a/src/test/java/com/icthh/xm/ms/mstemplate/config/SpringBootTestClassOrderer.java
+++ b/src/test/java/com/icthh/xm/ms/mstemplate/config/SpringBootTestClassOrderer.java
@@ -1,0 +1,23 @@
+package com.icthh.xm.ms.mstemplate.config;
+
+import com.icthh.xm.ms.mstemplate.IntegrationTest;
+import org.junit.jupiter.api.ClassDescriptor;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.ClassOrdererContext;
+
+import java.util.Comparator;
+
+public class SpringBootTestClassOrderer implements ClassOrderer {
+
+    @Override
+    public void orderClasses(ClassOrdererContext context) {
+        context.getClassDescriptors().sort(Comparator.comparingInt(SpringBootTestClassOrderer::getOrder));
+    }
+
+    private static int getOrder(ClassDescriptor classDescriptor) {
+        if (classDescriptor.findAnnotation(IntegrationTest.class).isPresent()) {
+            return 2;
+        }
+        return 1;
+    }
+}


### PR DESCRIPTION
Fix 
```
WARNING: Failed to load default class orderer class 'com.icthh.xm.ms.mstemplate.config.SpringBootTestClassOrderer' set via the 'junit.jupiter.testclass.order.default' configuration parameter. Falling back to default behavior.
java.lang.ClassNotFoundException: com.icthh.xm.ms.mstemplate.config.SpringBootTestClassOrderer
```
from logs